### PR TITLE
handle http request failures from circle when checking for artifacts

### DIFF
--- a/circle.go
+++ b/circle.go
@@ -124,6 +124,11 @@ func makeRequest(method, uri string) (io.ReadCloser, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("Request failed with status [%v]", resp.StatusCode)
+	}
+
 	return resp.Body, nil
 }
 
@@ -179,7 +184,6 @@ func GetArtifactsForBuild(org string, project string, buildNum int) ([]*CircleAr
 		return []*CircleArtifact{}, err
 	}
 	uri := getArtifactsUri(org, project, buildNum, token)
-	// TODO handle build not found, you get back {"message": "Build not found"}
 	body, err := makeRequest("GET", uri)
 	if err != nil {
 		return []*CircleArtifact{}, err

--- a/circle.go
+++ b/circle.go
@@ -127,7 +127,7 @@ func makeRequest(method, uri string) (io.ReadCloser, error) {
 
 	if resp.StatusCode >= 400 {
 		// TODO handle build not found, you get back {"message": "Build not found"}
-		return nil, fmt.Errorf("Request failed with status [%v]", resp.StatusCode)
+		return nil, fmt.Errorf("Request failed with status [%d]", resp.StatusCode)
 	}
 
 	return resp.Body, nil

--- a/circle.go
+++ b/circle.go
@@ -126,6 +126,7 @@ func makeRequest(method, uri string) (io.ReadCloser, error) {
 	}
 
 	if resp.StatusCode >= 400 {
+		// TODO handle build not found, you get back {"message": "Build not found"}
 		return nil, fmt.Errorf("Request failed with status [%v]", resp.StatusCode)
 	}
 


### PR DESCRIPTION
This fixes a problem we were running into while trying to download circle artifacts for a build that didn't exist (or when circle returned 500s)