### PR TITLE
Add help text and fix various lint errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 .PHONY: install test
 
+STATICCHECK := $(shell command -v staticcheck)
+BUMP_VERSION := $(shell command -v bump_version)
+
 install:
 	go install ./...
 
@@ -7,11 +10,21 @@ build:
 	go get ./...
 	go build ./...
 
-test: install
+lint: 
+	go vet ./...
+ifndef STATICCHECK
+	go get -u honnef.co/go/tools/cmd/staticcheck
+endif
+	staticcheck ./...
+
+test: install lint
 	go test -v -race ./...
 
 release:
 	git checkout master
+ifndef BUMP_VERSION
+	go get github.com/Shyp/bump_version
+endif
 	bump_version minor circle.go
 	git push origin master
 	git push origin master --tags

--- a/builds/build.go
+++ b/builds/build.go
@@ -1,80 +1,80 @@
 package build
 
 import (
-  "fmt"
+	"fmt"
 
-  "github.com/Shyp/go-circle"
-  "github.com/Shyp/go-git"
+	"github.com/Shyp/go-circle"
+	"github.com/Shyp/go-git"
 )
 
 func inSlice(a string, list []string) bool {
-  for _, b := range list {
-    if b == a {
-        return true
-    }
-  }
-  return false
+	for _, b := range list {
+		if b == a {
+			return true
+		}
+	}
+	return false
 }
 
 // GetBuilds gets the status of the 5 most recent Circle builds for a branch
 func GetBuilds(branch string) error {
-  // This throws if the branch doesn't exist
-  if _, err := git.Tip(branch); err != nil {
-    return err
-  }
+	// This throws if the branch doesn't exist
+	if _, err := git.Tip(branch); err != nil {
+		return err
+	}
 
-  fmt.Println("\nFetching recent builds for", branch, "starting with most recent commit\n")
+	fmt.Printf("\nFetching recent builds for %s starting with most recent commit\n\n", branch)
 
-  remote, err := git.GetRemoteURL("origin")
-  if err != nil {
-    return err
-  }
+	remote, err := git.GetRemoteURL("origin")
+	if err != nil {
+		return err
+	}
 
-  cr, err := circle.GetTree(remote.Path, remote.RepoName, branch)
-  if err != nil {
-    return err
-  }
+	cr, err := circle.GetTree(remote.Path, remote.RepoName, branch)
+	if err != nil {
+		return err
+	}
 
-  buildCount := 0
+	buildCount := 0
 
-  if len(*cr) < 5 {
-    buildCount = len(*cr)
-  } else {
-    buildCount = 5 // Limited to 5 most recent builds.
-  }
+	if len(*cr) < 5 {
+		buildCount = len(*cr)
+	} else {
+		buildCount = 5 // Limited to 5 most recent builds.
+	}
 
-  for i := 0; i < buildCount; i++ {
-    build := (*cr)[i]
-    ghUrl, url, status := build.CompareURL, build.BuildURL, build.Status
+	for i := 0; i < buildCount; i++ {
+		build := (*cr)[i]
+		ghUrl, url, status := build.CompareURL, build.BuildURL, build.Status
 
-    // Based on the status of the build, change the color of status print out
-    if build.Passed() {
-      status = fmt.Sprintf("\033[38;05;119m%-8s\033[0m", status)
-    } else if build.NotRunning(){
-      status = fmt.Sprintf("\033[38;05;20m%-8s\033[0m", status)
-    } else if build.Failed() {
-      status = fmt.Sprintf("\033[38;05;160m%-8s\033[0m", status)
-    } else if build.Running() {
-      status = fmt.Sprintf("\033[38;05;80m%-8s\033[0m", status)
-    } else {
-      status = fmt.Sprintf("\033[38;05;0m%-8s\033[0m", status)
-    }
+		// Based on the status of the build, change the color of status print out
+		if build.Passed() {
+			status = fmt.Sprintf("\033[38;05;119m%-8s\033[0m", status)
+		} else if build.NotRunning() {
+			status = fmt.Sprintf("\033[38;05;20m%-8s\033[0m", status)
+		} else if build.Failed() {
+			status = fmt.Sprintf("\033[38;05;160m%-8s\033[0m", status)
+		} else if build.Running() {
+			status = fmt.Sprintf("\033[38;05;80m%-8s\033[0m", status)
+		} else {
+			status = fmt.Sprintf("\033[38;05;0m%-8s\033[0m", status)
+		}
 
-    fmt.Println(url, status, ghUrl)
+		fmt.Println(url, status, ghUrl)
 
-  }
+	}
 
-  fmt.Println("\nMost recent build statuses fetched!")
+	fmt.Println("\nMost recent build statuses fetched!")
 
-  return nil
+	return nil
 }
 
 // CancelBuild cancels a build (as specified by the build number)
 func CancelBuild(org string, project string, buildNum int) string {
-  fmt.Printf("\nCanceling build: %d for %s\n\n", buildNum, project)
-  if _, err := circle.CancelBuild(org, project, buildNum); err != nil {
-    return ""
-  }
+	fmt.Printf("\nCanceling build: %d for %s\n\n", buildNum, project)
+	if _, err := circle.CancelBuild(org, project, buildNum); err != nil {
+		return ""
+	}
 
-  return ""
+	return ""
 }

--- a/circle/main.go
+++ b/circle/main.go
@@ -4,7 +4,6 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"strconv"
 
@@ -37,7 +36,6 @@ const downloadUsage = `usage: download-artifacts <build-num>`
 func usage() {
 	fmt.Fprintf(os.Stderr, help)
 	flag.PrintDefaults()
-	os.Exit(2)
 }
 
 func init() {
@@ -46,7 +44,8 @@ func init() {
 
 func checkError(err error) {
 	if err != nil {
-		log.Fatal(err)
+		os.Stderr.WriteString(err.Error() + "\n")
+		os.Exit(1)
 	}
 }
 
@@ -120,14 +119,12 @@ Wait for builds to complete, then print a descriptive output on
 success or failure.
 `)
 		waitflags.PrintDefaults()
-		os.Exit(2)
 	}
 	openflags := flag.NewFlagSet("open", flag.ExitOnError)
 	downloadflags := flag.NewFlagSet("download-artifacts", flag.ExitOnError)
 	downloadflags.Usage = func() {
 		fmt.Fprintf(os.Stderr, "%s\n\n", downloadUsage)
 		downloadflags.PrintDefaults()
-		os.Exit(1)
 	}
 
 	flag.Parse()
@@ -159,10 +156,8 @@ success or failure.
 			os.Exit(1)
 		}
 		downloadflags.Parse(args[1:])
-		if err := doDownload(downloadflags); err != nil {
-			log.Fatal(err)
-		}
-
+		err := doDownload(downloadflags)
+		checkError(err)
 	default:
 		usage()
 	}

--- a/token.go
+++ b/token.go
@@ -33,7 +33,10 @@ func getCaseInsensitiveOrg(key string, orgs map[string]organization) (organizati
 	if o, ok := orgs[lowerKey]; ok {
 		return o, nil
 	} else {
-		return organization{}, fmt.Errorf("Couldn't find organization %s in the config", key)
+		return organization{}, fmt.Errorf(`Couldn't find organization %s in the config.
+
+Go to https://circleci.com/account/api if you need to create a token.
+`, key)
 	}
 }
 

--- a/token_test.go
+++ b/token_test.go
@@ -1,6 +1,9 @@
 package circle
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestCaseInsensitive(t *testing.T) {
 	cfg := CircleConfig{
@@ -20,7 +23,7 @@ func TestCaseInsensitive(t *testing.T) {
 	if err == nil {
 		t.Fatalf("should not have found Shypmorelongname in the config, but did")
 	}
-	if err.Error() != "Couldn't find organization ShyPmorelongname in the config" {
+	if !strings.Contains(err.Error(), "Couldn't find organization ShyPmorelongname in the config") {
 		t.Fatalf("expected Couldn't find error message, got %v", err)
 	}
 }

--- a/wait/wait.go
+++ b/wait/wait.go
@@ -15,6 +15,7 @@ func roundDuration(d time.Duration, unit time.Duration) time.Duration {
 	return ((d + unit/2) / unit) * unit
 }
 
+// getStats returns a string with statistics about a given build number.
 func getStats(org string, project string, buildNum int) string {
 	build, err := circle.GetBuild(org, project, buildNum)
 	if err != nil {
@@ -129,7 +130,7 @@ func Wait(branch string) error {
 		duration = roundDuration(duration, time.Second)
 		if latestBuild.Passed() {
 			fmt.Printf("Build on %s succeeded!\n\n", branch)
-			fmt.Printf(getStats(remote.Path, remote.RepoName, latestBuild.BuildNum))
+			fmt.Print(getStats(remote.Path, remote.RepoName, latestBuild.BuildNum))
 			fmt.Printf("\nTests on %s took %s. Quitting.\n", branch, duration.String())
 			c := bigtext.Client{
 				Name:    fmt.Sprintf("%s (go-circle)", remote.RepoName),
@@ -138,7 +139,7 @@ func Wait(branch string) error {
 			c.Display(fmt.Sprintf("%s build complete!", branch))
 			break
 		} else if latestBuild.Failed() {
-			fmt.Printf(getStats(remote.Path, remote.RepoName, latestBuild.BuildNum))
+			fmt.Print(getStats(remote.Path, remote.RepoName, latestBuild.BuildNum))
 			fmt.Printf("\nURL: %s\n", latestBuild.BuildURL)
 			err = fmt.Errorf("Build on %s failed!\n\n", branch)
 			c := bigtext.Client{


### PR DESCRIPTION
- Run a linter when the tests run that checks for various formatting problems

- Fix problems suggested by the linter including:

    - Don't call os.Exit from the flag.Usage - flag has an ErrorHandling
      configuration that you should use to configure behavior instead, and it
      does the right thing by default (ExitOnError)

    - use fmt.Print instead of fmt.Printf when the first argument is dynamic

    - fix some other print statements

    - use os.Stderr.WriteString instead of log.Fatal to kill a process

    - fix tabbing in builds/build.go