### PR TITLE
Port GetTree to use kevinburke/rest

### DIFF
--- a/circle/main.go
+++ b/circle/main.go
@@ -129,10 +129,11 @@ func doEnable(flags *flag.FlagSet) error {
 func main() {
 	waitflags := flag.NewFlagSet("wait", flag.ExitOnError)
 	waitflags.Usage = func() {
-		fmt.Fprintf(os.Stderr, `usage: wait
+		fmt.Fprintf(os.Stderr, `usage: wait [refspec]
 
-Wait for builds to complete, then print a descriptive output on 
-success or failure.
+Wait for builds to complete, then print a descriptive output on success or
+failure. By default, waits on the current branch, otherwise you can pass a
+branch to wait for.
 `)
 		waitflags.PrintDefaults()
 	}


### PR DESCRIPTION
This lets us remove some of the request/decode boilerplate, and
adds auto-debuggability by setting DEBUG_HTTP_TRAFFIC=true in
your environment (instead of a Circle/binary-specific environment
variable).