### PR TITLE
Fixup git tip truncation

### DIFF
--- a/wait/wait.go
+++ b/wait/wait.go
@@ -95,21 +95,15 @@ func Wait(branch string) error {
 				remote.Path, remote.RepoName)
 		}
 		latestBuild := (*cr)[0]
-		var vcsLen int
-		var tipLen int
-		if len(latestBuild.VCSRevision) > 8 {
-			vcsLen = 8
+		var maxTipLength int
+		if len(latestBuild.VCSRevision) <= len(tip) {
+			maxTipLength = len(latestBuild.VCSRevision)
 		} else {
-			vcsLen = len(latestBuild.VCSRevision)
+			maxTipLength = len(tip)
 		}
-		if len(tip) > 8 {
-			tipLen = 8
-		} else {
-			tipLen = len(tip)
-		}
-		if latestBuild.VCSRevision[:tipLen] != tip {
+		if latestBuild.VCSRevision[:maxTipLength] != tip[:maxTipLength] {
 			fmt.Printf("Latest build in Circle is %s, waiting for %s...\n",
-				latestBuild.VCSRevision[:vcsLen], tip[:tipLen])
+				latestBuild.VCSRevision[:maxTipLength], tip[:maxTipLength])
 			time.Sleep(5 * time.Second)
 			continue
 		}

--- a/wait/wait.go
+++ b/wait/wait.go
@@ -68,6 +68,18 @@ func isHttpError(err error) bool {
 	}
 }
 
+// getMinTipLength compares two git hashes and returns the length of the
+// shortest
+func getMinTipLength(remoteTip string, localTip string) int {
+	var minTipLength int
+	if len(remoteTip) <= len(localTip) {
+		minTipLength = len(remoteTip)
+	} else {
+		minTipLength = len(localTip)
+	}
+	return minTipLength
+}
+
 func Wait(branch string) error {
 	remote, err := git.GetRemoteURL("origin")
 	if err != nil {
@@ -95,15 +107,10 @@ func Wait(branch string) error {
 				remote.Path, remote.RepoName)
 		}
 		latestBuild := (*cr)[0]
-		var maxTipLength int
-		if len(latestBuild.VCSRevision) <= len(tip) {
-			maxTipLength = len(latestBuild.VCSRevision)
-		} else {
-			maxTipLength = len(tip)
-		}
-		if latestBuild.VCSRevision[:maxTipLength] != tip[:maxTipLength] {
+		maxTipLengthToCompare := getMinTipLength(latestBuild.VCSRevision, tip)
+		if latestBuild.VCSRevision[:maxTipLengthToCompare] != tip[:maxTipLengthToCompare] {
 			fmt.Printf("Latest build in Circle is %s, waiting for %s...\n",
-				latestBuild.VCSRevision[:maxTipLength], tip[:maxTipLength])
+				latestBuild.VCSRevision[:maxTipLengthToCompare], tip[:maxTipLengthToCompare])
 			time.Sleep(5 * time.Second)
 			continue
 		}

--- a/wait/wait_test.go
+++ b/wait/wait_test.go
@@ -50,3 +50,23 @@ func TestEffectiveCost(t *testing.T) {
 		t.Errorf("expected half hour cost to be %d, was %d", 15793, cost)
 	}
 }
+
+func TestGetMaxTipLength(t *testing.T) {
+	minTipLength := getMinTipLength("1d79f2b877c86ac0964f3fe69a0171926aa6f1d8", "1d79f2b87")
+	expectedMinTipLength := 9
+	if minTipLength != expectedMinTipLength {
+		t.Errorf("expected half hour cost to be %d, was %d", expectedMinTipLength, minTipLength)
+	}
+
+	minTipLength = getMinTipLength("1d79f2b877c86ac0964f3fe69a0171926aa6f1d8", "1d79f2b")
+	expectedMinTipLength = 7
+	if minTipLength != expectedMinTipLength {
+		t.Errorf("expected half hour cost to be %d, was %d", expectedMinTipLength, minTipLength)
+	}
+
+	minTipLength = getMinTipLength("1d79f", "1d79f2b87")
+	expectedMinTipLength = 5
+	if minTipLength != expectedMinTipLength {
+		t.Errorf("expected half hour cost to be %d, was %d", expectedMinTipLength, minTipLength)
+	}
+}


### PR DESCRIPTION
This was broken for me because my local git environment would (sometimes) return 9 characters, which wasn't handled correctly when comparing the the two git commit hashes to determine which build was running.

[#142871959](https://www.pivotaltracker.com/story/show/142871959)